### PR TITLE
switch to absolute imports, add default entry point for development

### DIFF
--- a/mafia_rl_discord_bot/discord_bot.py
+++ b/mafia_rl_discord_bot/discord_bot.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 import discord
 import random
 import logging
-from .game import Game
+from mafia_rl_discord_bot.game import Game
 
 logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
@@ -128,3 +128,6 @@ def get_token() -> str:
 
 def run_bot() -> None:
     bot.run(get_token())
+
+if __name__ == "__main__":
+    run_bot()

--- a/mafia_rl_discord_bot/game.py
+++ b/mafia_rl_discord_bot/game.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
 
-from .voting import Voting
+from mafia_rl_discord_bot.voting import Voting
 
 
 class Game(commands.Cog):


### PR DESCRIPTION
* Running the python executable was erroring out for the relative imports for whatever reason. 
  * Switching to absolute imports seems to fix it.

Also updated `discord_bot.py` to automatically run the bot when the script is invoked