### PR TITLE
enable member intents to avoid voice channel caching issues

### DIFF
--- a/mafia_rl_discord_bot/discord_bot.py
+++ b/mafia_rl_discord_bot/discord_bot.py
@@ -12,8 +12,10 @@ handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w'
 handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
 logger.addHandler(handler)
 
-bot = commands.Bot(command_prefix='$')
+intents = discord.Intents.default()
+intents.members = True
 
+bot = commands.Bot(command_prefix='$', intents=intents)
 
 @bot.event
 async def on_ready():


### PR DESCRIPTION
You will have to make a change to the main bot account

See https://discordpy.readthedocs.io/en/latest/intents.html - Enable Member intents

---

> An intent basically allows a bot to subscribe into specific buckets of events

By enabling this specific Member intent(both in code and via the dev portal), the bot is now correctly able to determine accurate voice channel members. I'm not _exactly_ sure how this affects the cache, but I don't think enabling this can hurt, and seemed to positively affect things in my testing.

### Testing
 * Be in voice channel before starting up bot 
   * This fails without this change, bot does not grab anyone 
   * This works after this change, bot correctly detects my presence (not sure what about it causes it to work, but ¯\_(ツ)_/¯
 *  Join voice channel after starting up bot
    * This always works