### PR TITLE
Await the bot.cog

### DIFF
--- a/mafia_rl_discord_bot/discord_bot.py
+++ b/mafia_rl_discord_bot/discord_bot.py
@@ -104,7 +104,7 @@ async def initialize_game(ctx, num_of_mafias: int, members):
     await message.add_reaction('\U0001F537')
     await message.add_reaction('\U0001F536')
 
-    bot.add_cog(Game(bot, message, ctx.author, team_players, blue_team, orange_team, mafias, villagers))
+    await bot.add_cog(Game(bot, message, ctx.author, team_players, blue_team, orange_team, mafias, villagers))
 
 
 @bot.command()


### PR DESCRIPTION
I was seeing the error:

```
------
/home/wrl/discord_bots/mafia/mafiaBot/mafia_rl_discord_bot/discord_bot.py:109: RuntimeWarning: coroutine 'BotBase.add_cog' was never awaited
  bot.add_cog(Game(bot, message, ctx.author, team_players, blue_team, orange_team, mafias, villagers))
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

And the bot wasn't working.

Adding the await fixed it as the error said.